### PR TITLE
Separate note routes and add integration tests

### DIFF
--- a/FacilitesManagement.sln
+++ b/FacilitesManagement.sln
@@ -1,34 +1,47 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FacilitiesManagementAPI", "FacilitiesManagementAPI\FacilitiesManagementAPI.csproj", "{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FacilitiesManagementAPI.Tests", "FacilitiesManagementAPI.Tests\FacilitiesManagementAPI.Tests.csproj", "{E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}"
+EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|x64.Build.0 = Debug|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|x86.Build.0 = Debug|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|x64.ActiveCfg = Release|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|x64.Build.0 = Release|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|x86.ActiveCfg = Release|Any CPU
-		{C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Debug|x64 = Debug|x64
+                Debug|x86 = Debug|x86
+                Release|Any CPU = Release|Any CPU
+                Release|x64 = Release|x64
+                Release|x86 = Release|x86
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|x64.Build.0 = Debug|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Debug|x86.Build.0 = Debug|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|Any CPU.Build.0 = Release|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|x64.ActiveCfg = Release|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|x64.Build.0 = Release|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|x86.ActiveCfg = Release|Any CPU
+                {C96CBF6F-AB26-43DA-A317-B52BD5623FC4}.Release|x86.Build.0 = Release|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Debug|x64.Build.0 = Debug|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Debug|x86.Build.0 = Debug|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Release|x64.ActiveCfg = Release|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Release|x64.Build.0 = Release|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Release|x86.ActiveCfg = Release|Any CPU
+                {E021B6E7-5EBA-4F28-BDEE-0A4EED716A27}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal

--- a/FacilitiesManagementAPI.Tests/CustomWebApplicationFactory.cs
+++ b/FacilitiesManagementAPI.Tests/CustomWebApplicationFactory.cs
@@ -1,0 +1,105 @@
+using FacilitiesManagementAPI.Controllers;
+using FacilitiesManagementAPI.Data;
+using FacilitiesManagementAPI.Entities;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FacilitiesManagementAPI.Tests;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    public CustomWebApplicationFactory()
+    {
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Testing");
+    }
+
+    public Guid ExistingNoteId { get; } = Guid.Parse("c3b733e5-a3d6-4b25-a66a-8b57f5c39274");
+    public Guid SecondaryNoteId { get; } = Guid.Parse("b6f4c785-8b4a-42aa-bbb4-97579b0c12f5");
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting(WebHostDefaults.EnvironmentKey, "Testing");
+
+        builder.ConfigureAppConfiguration((context, configurationBuilder) =>
+        {
+            var settings = new Dictionary<string, string?>
+            {
+                ["TokenKey"] = "super_secret_testing_token_key"
+            };
+
+            configurationBuilder.AddInMemoryCollection(settings);
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            services.AddControllers().AddApplicationPart(typeof(NoteController).Assembly);
+
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<DataContext>));
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            var dbContextDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DataContext));
+            if (dbContextDescriptor != null)
+            {
+                services.Remove(dbContextDescriptor);
+            }
+
+            services.AddDbContext<DataContext>(options =>
+            {
+                options.UseInMemoryDatabase("FacilitiesManagementApiTests");
+            });
+
+            var sp = services.BuildServiceProvider();
+
+            using var scope = sp.CreateScope();
+            var scopedServices = scope.ServiceProvider;
+            var context = scopedServices.GetRequiredService<DataContext>();
+
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+
+            SeedDatabase(context);
+        });
+    }
+
+    private void SeedDatabase(DataContext context)
+    {
+        if (context.Note.Any())
+        {
+            return;
+        }
+
+        var premisesId = Guid.Parse("5f43a2df-64a0-4c29-832b-bf6cfdc45d78");
+
+        var firstNote = new Note
+        {
+            Id = ExistingNoteId,
+            NoteContent = "Routine safety inspection completed.",
+            IsPerm = true,
+            IsDeleted = false,
+            PremisesId = premisesId,
+            DateCreated = DateTime.SpecifyKind(new DateTime(2024, 1, 1, 8, 30, 0), DateTimeKind.Utc)
+        };
+
+        var secondNote = new Note
+        {
+            Id = SecondaryNoteId,
+            NoteContent = "Follow-up scheduled for next week.",
+            IsPerm = false,
+            IsDeleted = false,
+            PremisesId = premisesId,
+            DateCreated = DateTime.SpecifyKind(new DateTime(2024, 1, 2, 9, 45, 0), DateTimeKind.Utc)
+        };
+
+        context.Note.AddRange(firstNote, secondNote);
+        context.SaveChanges();
+    }
+}

--- a/FacilitiesManagementAPI.Tests/FacilitiesManagementAPI.Tests.csproj
+++ b/FacilitiesManagementAPI.Tests/FacilitiesManagementAPI.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.29" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.29" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FacilitiesManagementAPI\FacilitiesManagementAPI.csproj" />
+  </ItemGroup>
+</Project>

--- a/FacilitiesManagementAPI.Tests/NoteControllerTests.cs
+++ b/FacilitiesManagementAPI.Tests/NoteControllerTests.cs
@@ -1,0 +1,72 @@
+using System.Net;
+using System.Net.Http.Json;
+using FacilitiesManagementAPI.DTOs;
+using FacilitiesManagementAPI.Entities;
+using Xunit;
+
+namespace FacilitiesManagementAPI.Tests;
+
+public class NoteControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+
+    public NoteControllerTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetNotes_ReturnsOkWithNotes()
+    {
+        var response = await _client.GetAsync("/api/note");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var notes = await response.Content.ReadFromJsonAsync<List<Note>>();
+        Assert.NotNull(notes);
+        Assert.Contains(notes!, note => note.Id == _factory.ExistingNoteId &&
+                                        note.NoteContent == "Routine safety inspection completed.");
+        Assert.Contains(notes!, note => note.Id == _factory.SecondaryNoteId);
+    }
+
+    [Fact]
+    public async Task GetNote_ById_ReturnsSingleNote()
+    {
+        var response = await _client.GetAsync($"/api/note/{_factory.ExistingNoteId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var note = await response.Content.ReadFromJsonAsync<Note>();
+        Assert.NotNull(note);
+        Assert.Equal(_factory.ExistingNoteId, note!.Id);
+        Assert.Equal("Routine safety inspection completed.", note.NoteContent);
+    }
+
+    [Fact]
+    public async Task GetNotesDto_ReturnsOkWithNoteDtos()
+    {
+        var response = await _client.GetAsync("/api/note/dto");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var noteDtos = await response.Content.ReadFromJsonAsync<List<NoteDto>>();
+        Assert.NotNull(noteDtos);
+        Assert.Contains(noteDtos!, note => note.Id == _factory.ExistingNoteId &&
+                                           note.NoteContent == "Routine safety inspection completed.");
+    }
+
+    [Fact]
+    public async Task GetNoteDto_ById_ReturnsSingleNoteDto()
+    {
+        var response = await _client.GetAsync($"/api/note/dto/{_factory.ExistingNoteId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var noteDto = await response.Content.ReadFromJsonAsync<NoteDto>();
+        Assert.NotNull(noteDto);
+        Assert.Equal(_factory.ExistingNoteId, noteDto!.Id);
+        Assert.Equal("Routine safety inspection completed.", noteDto.NoteContent);
+    }
+}

--- a/FacilitiesManagementAPI/Controllers/NoteController.cs
+++ b/FacilitiesManagementAPI/Controllers/NoteController.cs
@@ -18,21 +18,24 @@ public class NoteController : BaseApiController
         var notes = await _unitOfWork.NoteRepository.GetNotesAsync();
         return Ok(notes);
     }
-    [HttpGet]
-    public async Task<ActionResult<Note>> GetNoteByIdAsync(Guid Id)
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<Note>> GetNoteAsync(Guid id)
     {
-        return await _unitOfWork.NoteRepository.GetNoteByIdAsync(Id);
+        return await _unitOfWork.NoteRepository.GetNoteByIdAsync(id);
     }
-    [HttpGet]
+
+    [HttpGet("dto")]
     public async Task<ActionResult<IEnumerable<NoteDto>>> GetNotesDtoAsync()
     {
         var notes = await _unitOfWork.NoteRepository.GetNotesDtoAsync();
         return Ok(notes);
     }
-    [HttpGet]
-    public async Task<ActionResult<NoteDto>> GetNoteDtoByIdAsync(Guid Id)
+
+    [HttpGet("dto/{id:guid}")]
+    public async Task<ActionResult<NoteDto>> GetNoteDtoAsync(Guid id)
     {
-        return await _unitOfWork.NoteRepository.GetNoteDtoByIdAsync(Id);
+        return await _unitOfWork.NoteRepository.GetNoteDtoByIdAsync(id);
     }
 
     [HttpPost("createNote")]

--- a/FacilitiesManagementAPI/Program.cs
+++ b/FacilitiesManagementAPI/Program.cs
@@ -21,7 +21,11 @@ app.UseAuthorization();
 app.UseDefaultFiles();
 app.UseStaticFiles();
 app.MapControllers();
-app.MapFallbackToController("Index", "Fallback");
+
+if (!app.Environment.IsEnvironment("Testing"))
+{
+    app.MapFallbackToController("Index", "Fallback");
+}
 
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
@@ -32,9 +36,12 @@ try
     var context = services.GetRequiredService<DataContext>();
     var userManager = services.GetRequiredService<UserManager<AppUser>>();
     var roleManager = services.GetRequiredService<RoleManager<AppRole>>();
-    await context.Database.MigrateAsync();
-    await Seed.SeedUsers(userManager, roleManager);
-    await Seed.SeedContractorType(context);
+    if (!string.Equals(context.Database.ProviderName, "Microsoft.EntityFrameworkCore.InMemory", StringComparison.Ordinal))
+    {
+        await context.Database.MigrateAsync();
+        await Seed.SeedUsers(userManager, roleManager);
+        await Seed.SeedContractorType(context);
+    }
 }
 catch (Exception ex)
 {
@@ -43,3 +50,7 @@ catch (Exception ex)
 }
 
 await app.RunAsync();
+
+public partial class Program
+{
+}


### PR DESCRIPTION
## Summary
- update the NoteController GET endpoints to use unique route templates while preserving repository calls
- adjust Program startup to skip fallback mapping and migrations during testing so the WebApplicationFactory host can initialize
- add a FacilitiesManagementAPI.Tests project with in-memory seeded data and integration tests covering each note endpoint

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d1373b48448327b9c89f1915f1b40e