### PR TITLE
Fix contractor linking dto and add integration test

### DIFF
--- a/FacilitiesManagementAPI.Tests/ContractorControllerTests.cs
+++ b/FacilitiesManagementAPI.Tests/ContractorControllerTests.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using System.Net.Http.Json;
+using FacilitiesManagementAPI.Data;
+using FacilitiesManagementAPI.DTOs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace FacilitiesManagementAPI.Tests;
+
+public class ContractorControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+
+    public ContractorControllerTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task LinkContractor_ReturnsOkAndPersistsLink()
+    {
+        var linkDto = new ContPremiseLinkDto
+        {
+            PremisesId = _factory.ExistingPremisesId,
+            ContractorId = _factory.ExistingContractorId
+        };
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<DataContext>();
+            var alreadyLinked = await context.PremisesContractors
+                .AsNoTracking()
+                .AnyAsync(pc => pc.PremisesId == linkDto.PremisesId && pc.ContractorId == linkDto.ContractorId);
+            Assert.False(alreadyLinked);
+        }
+
+        var response = await _client.PostAsJsonAsync("/api/contractor/linkContractor", linkDto);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<DataContext>();
+            var persistedLink = await context.PremisesContractors
+                .AsNoTracking()
+                .SingleOrDefaultAsync(pc => pc.PremisesId == linkDto.PremisesId && pc.ContractorId == linkDto.ContractorId);
+
+            Assert.NotNull(persistedLink);
+        }
+    }
+}
+

--- a/FacilitiesManagementAPI.Tests/CustomWebApplicationFactory.cs
+++ b/FacilitiesManagementAPI.Tests/CustomWebApplicationFactory.cs
@@ -18,6 +18,8 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 
     public Guid ExistingNoteId { get; } = Guid.Parse("c3b733e5-a3d6-4b25-a66a-8b57f5c39274");
     public Guid SecondaryNoteId { get; } = Guid.Parse("b6f4c785-8b4a-42aa-bbb4-97579b0c12f5");
+    public Guid ExistingPremisesId { get; } = Guid.Parse("5f43a2df-64a0-4c29-832b-bf6cfdc45d78");
+    public Guid ExistingContractorId { get; } = Guid.Parse("2f7cb6c6-68f4-4a27-a910-d008666c2bd9");
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -72,12 +74,51 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 
     private void SeedDatabase(DataContext context)
     {
-        if (context.Note.Any())
+        if (context.Premises.Any() || context.Contractors.Any() || context.Note.Any())
         {
             return;
         }
 
-        var premisesId = Guid.Parse("5f43a2df-64a0-4c29-832b-bf6cfdc45d78");
+        var premises = new Premises
+        {
+            Id = ExistingPremisesId,
+            PremiseNumber = "PM-001",
+            PremiseName = "Central Plaza",
+            IsDeleted = false,
+            PhoneNumber1 = "01234567890",
+            PhoneNumber2 = "09876543210",
+            Email = "contact@centralplaza.test",
+            PremisesAddress = new PremisesAddress
+            {
+                Id = Guid.Parse("0bb5a39e-1c8b-4b7b-8744-b72846a9d9f1"),
+                AddressLine1 = "1 Main Street",
+                AddressLine2 = "Suite 100",
+                City = "Metropolis",
+                Town = "Metropolis",
+                PostCode = "MP1 2AB",
+                IsDeleted = false,
+                PremisesId = ExistingPremisesId
+            },
+            IsArchieved = false
+        };
+
+        var contractor = new Contractor
+        {
+            Id = ExistingContractorId,
+            BusinessName = "Trusted Contractors Ltd",
+            FirstName = "Alex",
+            LastName = "Taylor",
+            ContractorTypeId = null,
+            GreenLightEnum = "Green",
+            PhoneNumber1 = "01111111111",
+            PhoneNumber2 = "02222222222",
+            Email = "alex.taylor@trustedcontractors.test",
+            IsDeleted = false,
+            DateCreated = DateTime.SpecifyKind(new DateTime(2024, 1, 1, 0, 0, 0), DateTimeKind.Utc)
+        };
+
+        context.Premises.Add(premises);
+        context.Contractors.Add(contractor);
 
         var firstNote = new Note
         {
@@ -85,7 +126,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             NoteContent = "Routine safety inspection completed.",
             IsPerm = true,
             IsDeleted = false,
-            PremisesId = premisesId,
+            PremisesId = ExistingPremisesId,
             DateCreated = DateTime.SpecifyKind(new DateTime(2024, 1, 1, 8, 30, 0), DateTimeKind.Utc)
         };
 
@@ -95,7 +136,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             NoteContent = "Follow-up scheduled for next week.",
             IsPerm = false,
             IsDeleted = false,
-            PremisesId = premisesId,
+            PremisesId = ExistingPremisesId,
             DateCreated = DateTime.SpecifyKind(new DateTime(2024, 1, 2, 9, 45, 0), DateTimeKind.Utc)
         };
 

--- a/FacilitiesManagementAPI/Controllers/ContractorController.cs
+++ b/FacilitiesManagementAPI/Controllers/ContractorController.cs
@@ -48,9 +48,9 @@ public class ContractorController : BaseApiController
     }
 
     [HttpPost("linkContractor")]
-    public async Task<ActionResult<PremisesContractor>> CreateContractorLink(CreateContractorDto createContractorDto)
+    public async Task<ActionResult<PremisesContractor>> CreateContractorLink(ContPremiseLinkDto contPremiseLinkDto)
     {
-        var conLink = _mapper.Map<PremisesContractor>(createContractorDto);
+        var conLink = _mapper.Map<PremisesContractor>(contPremiseLinkDto);
 
         _context.PremisesContractors.Add(conLink);
         await _unitOfWork.Complete();


### PR DESCRIPTION
## Summary
- update the contractor link endpoint to accept ContPremiseLinkDto and map correctly
- seed the test web host with contractor and premises data to support link scenarios
- add an integration test that posts a contractor-premises link and verifies persistence

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d13bd9735083279bc64a81dbbc4edd