### PR TITLE
Update contractor type seeding guard and add tests

### DIFF
--- a/FacilitiesManagementAPI.Tests/SeedTests.cs
+++ b/FacilitiesManagementAPI.Tests/SeedTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FacilitiesManagementAPI.Data;
+using FacilitiesManagementAPI.Entities;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace FacilitiesManagementAPI.Tests;
+
+public class SeedTests
+{
+    [Fact]
+    public async Task SeedContractorType_AddsTypesWhenMissingEvenIfContractorsExist()
+    {
+        var options = new DbContextOptionsBuilder<DataContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new DataContext(options);
+        context.Contractors.Add(new Contractor
+        {
+            Id = Guid.NewGuid(),
+            BusinessName = "Test Business",
+            FirstName = "Test",
+            LastName = "Contractor",
+            GreenLightEnum = "Green",
+            PhoneNumber1 = "1234567890",
+            Email = "test@example.com",
+            IsDeleted = false
+        });
+        await context.SaveChangesAsync();
+
+        using (UseSeedDataDirectory())
+        {
+            await Seed.SeedContractorType(context);
+        }
+
+        var contractorTypes = await context.ContractorTypes.ToListAsync();
+
+        Assert.NotEmpty(contractorTypes);
+        Assert.Contains(contractorTypes, type => type.TypeDescription == "Plumber");
+    }
+
+    [Fact]
+    public async Task SeedContractorType_SkipsWhenTypesAlreadyExist()
+    {
+        var options = new DbContextOptionsBuilder<DataContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new DataContext(options);
+        context.ContractorTypes.Add(new ContractorType
+        {
+            Id = 1,
+            TypeDescription = "Existing",
+            IsDeleted = false
+        });
+        await context.SaveChangesAsync();
+
+        using (UseSeedDataDirectory())
+        {
+            await Seed.SeedContractorType(context);
+        }
+
+        var contractorTypes = await context.ContractorTypes.ToListAsync();
+
+        Assert.Single(contractorTypes);
+        Assert.Equal("Existing", contractorTypes[0].TypeDescription);
+    }
+
+    private static IDisposable UseSeedDataDirectory()
+    {
+        var originalDirectory = Directory.GetCurrentDirectory();
+        var projectDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "FacilitiesManagementAPI"));
+        Directory.SetCurrentDirectory(projectDirectory);
+        return new DirectoryScope(originalDirectory);
+    }
+
+    private sealed class DirectoryScope : IDisposable
+    {
+        private readonly string _originalDirectory;
+        private bool _disposed;
+
+        public DirectoryScope(string originalDirectory)
+        {
+            _originalDirectory = originalDirectory;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            Directory.SetCurrentDirectory(_originalDirectory);
+            _disposed = true;
+        }
+    }
+}

--- a/FacilitiesManagementAPI/Data/Seed.cs
+++ b/FacilitiesManagementAPI/Data/Seed.cs
@@ -1,4 +1,5 @@
  using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -89,14 +90,15 @@ namespace FacilitiesManagementAPI.Data
 
         public static async Task SeedContractorType(DataContext context)
         {
-            if (await context.Contractors.AnyAsync()) return;
+            if (await context.ContractorTypes.AnyAsync()) return;
+
             var contractorTypeData = await System.IO.File.ReadAllTextAsync("Data/ContractorType.json");
             var conTypes = JsonSerializer.Deserialize<List<ContractorType>>(contractorTypeData);
-            foreach (var conType in conTypes)
-            { 
-                context.ContractorTypes.Add(conType);
-            }
-            context.SaveChanges();
+
+            if (conTypes == null || !conTypes.Any()) return;
+
+            await context.ContractorTypes.AddRangeAsync(conTypes);
+            await context.SaveChangesAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure contractor type seeding checks for existing types before loading seed data
- add unit tests for the contractor type seeding covering missing types and existing types

## Testing
- /usr/share/dotnet/dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d13f10e7908327bbb8a3d783c393f1