### PR TITLE
Handle missing cached user before parsing

### DIFF
--- a/client/src/app/_services/account.service.ts
+++ b/client/src/app/_services/account.service.ts
@@ -10,7 +10,7 @@ import { User } from '../_models/user';
 })
 export class AccountService {
   baseUrl = environment.apiUrl;
-  private currentUserSource = new ReplaySubject<User>(1);
+  private currentUserSource = new ReplaySubject<User | null>(1);
   currentUser$ = this.currentUserSource.asObservable();
 
   constructor(private http: HttpClient) { }
@@ -41,7 +41,12 @@ export class AccountService {
     //   )
     // )
   }
-  setCurrentUser(user: User) {
+  setCurrentUser(user: User | null | undefined) {
+    if (!user) {
+      localStorage.removeItem('user');
+      this.currentUserSource.next(null);
+      return;
+    }
     user.roles = [];
     const roles = this.getDecodedToken(user.token).role;
     Array.isArray(roles) ? user.roles = roles : user.roles.push(roles);

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -18,7 +18,12 @@ export class AppComponent implements OnInit {
   }
 
   setCurrentUser(){
-    const user: User = JSON.parse(localStorage.getItem('user'));
+    const storedUser = localStorage.getItem('user');
+    if (!storedUser) {
+      return;
+    }
+
+    const user: User = JSON.parse(storedUser);
     this.accounntService.setCurrentUser(user);
   }
 


### PR DESCRIPTION
## Summary
- skip parsing local storage when the app component loads without a cached user
- short-circuit account service initialization when called with a falsy user to keep the subject in sync

## Testing
- npm install *(fails: dependency conflict between @angular-devkit/build-angular@20.3.2 and @angular/compiler-cli@14.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d1684973848327a1f79e611f3f66d2